### PR TITLE
fix: information text not rendering html

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -39,8 +39,7 @@ export const configFields = [
     width: 12,
     id: 'info',
     label: 'Information',
-    value: `
-    Remotely control <a href="https://stagetimer.io/" target="_blank">Stagetimer.io</a> using Companion.<br><br>
+    value: `<br />Remotely control <a href="https://stagetimer.io/" target="_blank">Stagetimer.io</a> using Companion.<br><br>
     Requires a Stagetimer.io account on a <b>paid plan</b> (<i>Pro</i> or <i>Premium</i>).<br><br>
     Enter your <b>Room ID</b> and <b>API key</b> below to get started.<br>
     You can generate an API key on the controller page.


### PR DESCRIPTION
Due to starting the information text in the config.js with a line break, Companion was not rendering the html and was showing it as text.  By replacing the line break with an html line break, Companion will render the html.  This might also be a Companion v4.0 bug causing the rendering issue.