### PR TITLE
Release v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 
+## v2.5.0
+
+New features:
+- Adds a `Fullscreen` checkbox option to the `Message: Show` and `Message: Toggle visibility` actions. Enabling it shows the message in fullscreen mode, covering all other output elements (sent as `focus=true` to the API). This matches the renamed "Fullscreen" mode in the Stagetimer UI.
+
+Changes:
+- Marks `Viewer: Enable focus mode`, `Viewer: Disable focus mode`, and `Viewer: Toggle focus mode` as `(legacy)`. Prefer `Message: Show` with the `Fullscreen` option going forward. Existing buttons using these actions continue to work.
+- Removes the `Toggle focus mode` preset. The underlying actions remain available.
+
 ## v2.4.0
 
 New features:

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -38,7 +38,7 @@ There are multiple presets available for the most common actions, ready to drop 
 The presets are organized into categories:
 
 - **Transport**: Start/Stop, Previous, Next, Add/Subtract time
-- **Viewer**: Time display, Wrap-up indicator, Flash, Blackout, Focus mode
+- **Viewer**: Time display, Wrap-up indicator, Flash, Blackout
 - **Timer**: Reset, Start, Stop specific timers
 - **Message**: Toggle, Show, Hide, Create messages
 
@@ -56,9 +56,9 @@ The following Actions are available:
 - **Message: Hide**  
     Hide a message in the room
 - **Message: Show**  
-    Show a message in the room
+    Show a message in the room. Enable "Fullscreen" to cover all other output elements.
 - **Message: Toggle visibility**  
-    Show/hide a message in the room
+    Show/hide a message in the room. When showing, enable "Fullscreen" to cover all other output elements.
 - **Message: Create new message**  
     Create a new message in the room
 
@@ -100,26 +100,26 @@ The following Actions are available:
 
 - **Viewer: Disable blackout mode**  
     Disable blackout mode in the room
-- **Viewer: Disable focus mode**  
-    Disable focus mode in the room
 - **Viewer: Enable blackout mode**  
     Enable blackout mode in the room
-- **Viewer: Enable focus mode**  
-    Enable focus mode in the room
 - **Viewer: Flash the screen**  
     Flashes the screen in the room. Can be used to grab the attention of speakers.
 - **Viewer: Stop flashing**  
     Stops any flashing timers and message on the screen.
 - **Viewer: Toggle blackout mode**  
     Toggle (enable/disable) blackout mode in the room
-- **Viewer: Toggle focus mode**
-    Toggle (enable/disable) focus mode in the room
 - **Viewer: Enable ON AIR**
     Enable ON AIR mode in the room
 - **Viewer: Disable ON AIR**
     Disable ON AIR mode in the room
 - **Viewer: Toggle ON AIR**
     Toggle (enable/disable) ON AIR mode in the room
+- **Viewer: Enable focus mode (legacy)**  
+    Legacy: Use "Message: Show" with the "Fullscreen" option instead.
+- **Viewer: Disable focus mode (legacy)**  
+    Legacy: Use "Message: Hide" instead.
+- **Viewer: Toggle focus mode (legacy)**  
+    Legacy: Use "Message: Show" with the "Fullscreen" option instead.
 
 **Utility actions:**
 

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
   "name": "stagetimer",
   "shortname": "stagetimer",
   "description": "Stagetimer.io module for Companion v3",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "license": "MIT",
   "repository": "git+https://github.com/bitfocus/companion-module-stagetimerio-api.git",
   "bugs": "https://github.com/bitfocus/companion-module-stagetimerio-api/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagetimerio-api",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Stagetimer.io module for Companion v3",
   "main": "src/index.js",
   "type": "module",

--- a/src/actions.js
+++ b/src/actions.js
@@ -304,6 +304,31 @@ const actionOptions = {
       tooltip: 'The ID of the message you want to target.',
     },
   ],
+  messageShow: [
+    {
+      id: 'index',
+      type: 'number',
+      label: 'Message index',
+      // @ts-expect-error: According to Companion docs, `default: ''` should work for optional, but is of course a type error.
+      default: '',
+      min: 1,
+      max: 99,
+      tooltip: 'Index of a message to target in a room. Note: Index is not zero-based, it starts at 1. Example: To target the second message from the top, set `index=2`. Leave blank to target active or first message.',
+    },
+    {
+      id: 'message_id',
+      type: 'textinput',
+      label: 'Message ID',
+      tooltip: 'The ID of the message you want to target.',
+    },
+    {
+      id: 'focus',
+      type: 'checkbox',
+      label: 'Fullscreen',
+      default: false,
+      tooltip: 'Show the message in fullscreen mode, covering all other output elements.',
+    },
+  ],
   messageCreate: [
     {
       id: 'text',
@@ -430,20 +455,20 @@ export function loadActions (instance) {
       callback: actionCallback,
     },
     [actionIdType.enable_focus]: {
-      name: 'Viewer: Enable focus mode',
-      description: 'Enable focus mode in the room',
+      name: 'Viewer: Enable focus mode (legacy)',
+      description: 'Legacy: Use "Message: Show" with the "Fullscreen" option instead. Enables focus mode in the room.',
       options: [],
       callback: actionCallback,
     },
     [actionIdType.disable_focus]: {
-      name: 'Viewer: Disable focus mode',
-      description: 'Disable focus mode in the room',
+      name: 'Viewer: Disable focus mode (legacy)',
+      description: 'Legacy: Use "Message: Hide" instead. Disables focus mode in the room.',
       options: [],
       callback: actionCallback,
     },
     [actionIdType.toggle_focus]: {
-      name: 'Viewer: Toggle focus mode',
-      description: 'Toggle (enable/disable) focus mode in the room',
+      name: 'Viewer: Toggle focus mode (legacy)',
+      description: 'Legacy: Use "Message: Show" with the "Fullscreen" option instead. Toggles (enable/disable) focus mode in the room.',
       options: [],
       callback: actionCallback,
     },
@@ -507,8 +532,8 @@ export function loadActions (instance) {
     // Message actions
     [actionIdType.show_message]: {
       name: 'Message: Show',
-      description: 'Show a message in the room',
-      options: actionOptions.message,
+      description: 'Show a message in the room. Enable "Fullscreen" to cover all other output elements.',
+      options: actionOptions.messageShow,
       callback: actionCallback,
     },
     [actionIdType.hide_message]: {
@@ -519,8 +544,8 @@ export function loadActions (instance) {
     },
     [actionIdType.show_or_hide_message]: {
       name: 'Message: Toggle visibility',
-      description: 'Show/hide a message in the room',
-      options: actionOptions.message,
+      description: 'Show/hide a message in the room. When showing, enable "Fullscreen" to cover all other output elements.',
+      options: actionOptions.messageShow,
       callback: actionCallback,
     },
     [actionIdType.create_message]: {

--- a/src/presets.js
+++ b/src/presets.js
@@ -386,24 +386,6 @@ function generatePresets () {
         ],
       },
       {
-        name: 'Toggle focus mode',
-        actionId: actionIdType.toggle_focus,
-        style: {
-          size: '14',
-          text: 'Focus',
-          alignment: 'center:bottom',
-          png64: icons.focus,
-          pngalignment: 'center:top',
-          color: colors.white,
-          bgcolor: colors.black,
-        },
-        feedbacks: [
-          getFeedbackDefaults(feedbackType.focusEnabled, {
-            png64: icons.focusOff,
-          }),
-        ],
-      },
-      {
         name: 'Toggle ON AIR mode',
         actionId: actionIdType.toggle_on_air,
         style: {


### PR DESCRIPTION
New features:
- Adds a `Fullscreen` checkbox option to the `Message: Show` and `Message: Toggle visibility` actions. Enabling it shows the message in fullscreen mode, covering all other output elements (sent as `focus=true` to the API). This matches the renamed "Fullscreen" mode in the Stagetimer UI.

Changes:
- Marks `Viewer: Enable focus mode`, `Viewer: Disable focus mode`, and `Viewer: Toggle focus mode` as `(legacy)`. Prefer `Message: Show` with the `Fullscreen` option going forward. Existing buttons using these actions continue to work.
- Removes the `Toggle focus mode` preset. The underlying actions remain available.