### PR TITLE
Version v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,23 @@
 # Changelog
 
 
+## v2.6.0
+
+New features:
+- Adds variables for the message currently showing on the viewer:
+  - `$(stagetimer:currentMessageId)` - Message ID
+  - `$(stagetimer:currentMessageText)` - Message text
+  - `$(stagetimer:currentMessageColor)` - Message color
+  - The variables are empty while no message is showing.
+
+Fixes:
+- Fixes targeting a timer by ID in the `Timer: Start`, `Timer: Stop`, `Timer: Toggle playback`, `Timer: Reset`, and `Timer: Update timer` actions. The `Timer ID` field now supports variables (e.g. `$(stagetimer:currentTimerId)`), and the `Timer index` field can be left blank. Previously the index was always sent alongside the ID, which the API rejects, so the action did nothing.
+- Adds variable support to the `Message ID` field of the message actions.
+
+Changes:
+- The `Timer index` and `Message index` fields are now text inputs (instead of number inputs) so they can be cleared and accept variables. Existing buttons keep working unchanged.
+- When both an index and an ID are set, the ID now takes precedence instead of the request failing.
+
 ## v2.5.0
 
 New features:

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -77,6 +77,8 @@ The following Actions are available:
 - **Timer: Update timer**
     Update an existing timer in the room
 
+The `Timer: *` and `Message: *` actions target either an index (position in the list, starting at 1) or an ID. Use one or the other — if both fields are filled, the ID wins. Both fields accept variables, so setting `Timer ID` to `$(stagetimer:currentTimerId)` and clearing `Timer index` targets the currently highlighted timer.
+
 **Transport actions:**
 
 - **Transport: Add time**  
@@ -185,6 +187,13 @@ The time display is equal to the Stagetimer output, taking [timer appearance](ht
 - `$(stagetimer:nextTimerLabel1)` - Timer label 1
 - `$(stagetimer:nextTimerLabel2)` - Timer label 2
 - `$(stagetimer:nextTimerLabel3)` - Timer label 3
+
+**Current Message**  
+The message currently showing on the viewer. These variables are empty while no message is showing.
+
+- `$(stagetimer:currentMessageId)` - Message ID
+- `$(stagetimer:currentMessageText)` - Message text
+- `$(stagetimer:currentMessageColor)` - Message color
 
 ---
 

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
   "name": "stagetimer",
   "shortname": "stagetimer",
   "description": "Stagetimer.io module for Companion v3",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "license": "MIT",
   "repository": "git+https://github.com/bitfocus/companion-module-stagetimerio-api.git",
   "bugs": "https://github.com/bitfocus/companion-module-stagetimerio-api/issues",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,12 @@
     "url": "git+https://github.com/bitfocus/companion-module-stagetimerio-api.git"
   },
   "dependencies": {
-    "@companion-module/base": "^1.14.0",
-    "socket.io-client": "^4.8.1"
+    "@companion-module/base": "^1.14.1",
+    "socket.io-client": "^4.8.3"
   },
   "devDependencies": {
-    "@companion-module/tools": "^2.6.1",
-    "eslint": "^10.0.3"
+    "@companion-module/tools": "^2.7.2",
+    "eslint": "^10.8.0"
   },
   "packageManager": "yarn@4.12.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagetimerio-api",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Stagetimer.io module for Companion v3",
   "main": "src/index.js",
   "type": "module",

--- a/src/actions.js
+++ b/src/actions.js
@@ -104,18 +104,18 @@ const actionOptions = {
   timer: [
     {
       id: 'index',
-      type: 'number',
+      type: 'textinput',
       label: 'Timer index',
-      default: 1,
-      min: 1,
-      max: 99,
-      tooltip: 'Index of a timer to target in a room. Note: Index is not zero-based, it starts at 1. Example: To target the second timer from the top, set `index=2`.',
+      default: '1',
+      useVariables: true,
+      tooltip: 'Index of a timer to target in a room. Note: Index is not zero-based, it starts at 1. Example: To target the second timer from the top, set `index=2`. Leave blank when targeting a timer by ID.',
     },
     {
       id: 'timer_id',
       type: 'textinput',
       label: 'Timer ID',
-      tooltip: 'The ID of the timer you want to target.',
+      useVariables: true,
+      tooltip: 'The ID of the timer you want to target. Takes precedence over the timer index. Tip: Use `$(stagetimer:currentTimerId)` to target the currently highlighted timer.',
     },
   ],
   timerCreate: [
@@ -289,37 +289,35 @@ const actionOptions = {
   message: [
     {
       id: 'index',
-      type: 'number',
+      type: 'textinput',
       label: 'Message index',
-      // @ts-expect-error: According to Companion docs, `default: ''` should work for optional, but is of course a type error.
       default: '',
-      min: 1,
-      max: 99,
+      useVariables: true,
       tooltip: 'Index of a message to target in a room. Note: Index is not zero-based, it starts at 1. Example: To target the second message from the top, set `index=2`. Leave blank to target active or first message.',
     },
     {
       id: 'message_id',
       type: 'textinput',
       label: 'Message ID',
-      tooltip: 'The ID of the message you want to target.',
+      useVariables: true,
+      tooltip: 'The ID of the message you want to target. Takes precedence over the message index.',
     },
   ],
   messageShow: [
     {
       id: 'index',
-      type: 'number',
+      type: 'textinput',
       label: 'Message index',
-      // @ts-expect-error: According to Companion docs, `default: ''` should work for optional, but is of course a type error.
       default: '',
-      min: 1,
-      max: 99,
+      useVariables: true,
       tooltip: 'Index of a message to target in a room. Note: Index is not zero-based, it starts at 1. Example: To target the second message from the top, set `index=2`. Leave blank to target active or first message.',
     },
     {
       id: 'message_id',
       type: 'textinput',
       label: 'Message ID',
-      tooltip: 'The ID of the message you want to target.',
+      useVariables: true,
+      tooltip: 'The ID of the message you want to target. Takes precedence over the message index.',
     },
     {
       id: 'focus',
@@ -626,6 +624,9 @@ async function sendActionToApi ({ actionId, options }) {
 
   const params = assignTruthyOptionsToParams(options)
 
+  // Make sure only one of `index` and `timer_id`/`message_id` is sent
+  resolveTargetParams(params)
+
   // Convert label options to labels array format
   convertLabelsToApiFormat(params)
 
@@ -642,16 +643,35 @@ async function sendActionToApi ({ actionId, options }) {
 
 /**
  * Filters Action options ({@link CompanionOptionValues}) for falsy values,
- * so that only truthy ones are used as query params.
+ * so that only truthy ones are used as query params. Empty strings are kept,
+ * because they are a valid value for text fields like `text` or `name`.
  *
  * @param {CompanionOptionValues} options
  * @returns {object}
  */
-function assignTruthyOptionsToParams (options) {
+export function assignTruthyOptionsToParams (options) {
   return Object.fromEntries(
     // Note: != null filters both null and undefined (loose equality)
     Object.entries(options).filter(([_key, value]) => value != null && value !== false),
   )
+}
+
+/**
+ * The API requires either `index` OR an ID to identify a timer/message and
+ * rejects requests containing both. Trims the values, drops the blank ones,
+ * and lets the ID win. Modifies the params object in place.
+ *
+ * @param {object} params
+ * @returns {void}
+ */
+export function resolveTargetParams (params) {
+  for (const key of ['index', 'timer_id', 'message_id']) {
+    if (typeof params[key] !== 'string') continue
+    params[key] = params[key].trim()
+    if (!params[key]) delete params[key]
+  }
+
+  if (params.timer_id || params.message_id) delete params.index
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import { InstanceBase, runEntrypoint, InstanceStatus } from '@companion-module/base'
 import { initialConfig, validateConfig, configFields } from './config.js'
-import { initialState } from './state.js'
+import { initialState, updateMessageState } from './state.js'
 import { ApiClient } from './api.js'
 import { socketStart, socketStop } from './socket.js'
 import { loadActions } from './actions.js'
@@ -58,6 +58,10 @@ export class ModuleInstance extends InstanceBase {
       loadFeedbacks(this)
       loadVariables(this)
       loadPresets(this)
+
+      // The API only emits a `message` event when a message is active, so seed
+      // the message variables to keep them from showing up as undefined.
+      updateMessageState.call(this)
     } catch (error) {
       if(error instanceof Error) {
         throw new Error(`Failed to start. Error: ${error.message}`)

--- a/src/presets.js
+++ b/src/presets.js
@@ -408,7 +408,7 @@ function generatePresets () {
         name: 'Reset a timer',
         actionId: actionIdType.reset_timer,
         actionOptions: {
-          index: 1,
+          index: '1',
         },
         style: {
           size: '14',
@@ -425,7 +425,7 @@ function generatePresets () {
         name: 'Start a timer',
         actionId: actionIdType.start_timer,
         actionOptions: {
-          index: 2,
+          index: '2',
         },
         style: {
           size: '14',
@@ -442,7 +442,7 @@ function generatePresets () {
         name: 'Stop a timer',
         actionId: actionIdType.stop_timer,
         actionOptions: {
-          index: 2,
+          index: '2',
         },
         style: {
           size: '14',

--- a/src/socket.js
+++ b/src/socket.js
@@ -296,9 +296,10 @@ export function socketStart (instance) {
   socket.on(stagetimerEvents.message, (payload) => {
     instance.log('debug', `Event: 'message' ${JSON.stringify(payload)}`)
 
-    const { showing, text, color, bold, uppercase } = payload
+    const { _id, showing, text, color, bold, uppercase } = payload
 
     updateMessageState.call(instance, {
+      _id,
       showing,
       text,
       color,

--- a/src/state.js
+++ b/src/state.js
@@ -114,6 +114,7 @@ export const initialState = {
     labels: [],
   },
   message: {
+    _id: '',
     showing: false,
     text: '',
     color: '',
@@ -320,7 +321,7 @@ export function updateNextTimerState (newState) {
 }
 
 /**
- * @param { MessageState } newState
+ * @param { MessageState } [newState]
  * @this {ModuleInstance}
  * @returns {void}
  */
@@ -328,10 +329,22 @@ export function updateMessageState (newState) {
 
   const instance = this
 
-  instance.state.message = {
+  const updatedState = {
     ...instance.state.message,
     ...newState,
   }
+
+  instance.state.message = updatedState
+
+  // The API keeps sending the message after it was hidden, but a message that
+  // isn't on the viewer is not the "current" message.
+  const showing = updatedState.showing
+
+  instance.setVariableValues({
+    [variableType.currentMessageId]: showing ? updatedState._id || '' : '',
+    [variableType.currentMessageText]: showing ? updatedState.text : '',
+    [variableType.currentMessageColor]: showing ? updatedState.color : '',
+  })
 
   instance.checkFeedbacks(
     feedbackType.messageIsShowing,

--- a/src/types.js
+++ b/src/types.js
@@ -147,6 +147,7 @@
 
 /**
  * @typedef {object} MessageState
+ * @property {string} [_id]
  * @property {boolean} showing
  * @property {string} text
  * @property {string} color

--- a/src/variables.js
+++ b/src/variables.js
@@ -52,6 +52,11 @@ export const variableType = {
   nextTimerLabel1: 'nextTimerLabel1',
   nextTimerLabel2: 'nextTimerLabel2',
   nextTimerLabel3: 'nextTimerLabel3',
+
+  // Current Message
+  currentMessageId: 'currentMessageId',
+  currentMessageText: 'currentMessageText',
+  currentMessageColor: 'currentMessageColor',
 }
 
 /** @type {CompanionVariableDefinition[]} */
@@ -103,6 +108,11 @@ const variables = [
   { variableId: variableType.nextTimerLabel1, name: 'Next timer label 1' },
   { variableId: variableType.nextTimerLabel2, name: 'Next timer label 2' },
   { variableId: variableType.nextTimerLabel3, name: 'Next timer label 3' },
+
+  // Current Message
+  { variableId: variableType.currentMessageId, name: 'Current message ID' },
+  { variableId: variableType.currentMessageText, name: 'Current message text' },
+  { variableId: variableType.currentMessageColor, name: 'Current message color' },
 ]
 
 /**

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -47,7 +47,7 @@ describe('actions.resolveTargetParams', () => {
     )
   })
 
-  test('numeric index from actions saved before v2.6.0 still works', () => {
+  test('numeric index from actions saved with older module versions still works', () => {
     deepEqual(toParams({ index: 1, timer_id: '' }), { index: 1 })
     deepEqual(toParams({ index: 1, timer_id: 'abc' }), { timer_id: 'abc' })
   })

--- a/tests/actions.test.js
+++ b/tests/actions.test.js
@@ -1,0 +1,58 @@
+import { describe, test } from 'node:test'
+import { deepEqual } from 'node:assert/strict'
+
+import { assignTruthyOptionsToParams, resolveTargetParams } from '../src/actions.js'
+
+/** Helper mirroring what sendActionToApi() does with the action options */
+function toParams (options) {
+  const params = assignTruthyOptionsToParams(options)
+  resolveTargetParams(params)
+  return params
+}
+
+describe('actions.assignTruthyOptionsToParams', () => {
+  test('filters undefined, null and false values', () => {
+    deepEqual(
+      assignTruthyOptionsToParams({ name: undefined, notes: null, focus: false, autostart: true, amount: '5s' }),
+      { autostart: true, amount: '5s' },
+    )
+  })
+
+  test('keeps empty strings, they are a valid value for text fields', () => {
+    deepEqual(assignTruthyOptionsToParams({ text: '', name: '' }), { text: '', name: '' })
+  })
+})
+
+describe('actions.resolveTargetParams', () => {
+  test('timer ID takes precedence over index', () => {
+    deepEqual(
+      toParams({ index: '1', timer_id: '63f59467d68bfdeef6b3bfc3' }),
+      { timer_id: '63f59467d68bfdeef6b3bfc3' },
+    )
+  })
+
+  test('index is used when no timer ID is set', () => {
+    deepEqual(toParams({ index: '4', timer_id: '' }), { index: '4' })
+  })
+
+  test('whitespace-only values are dropped', () => {
+    deepEqual(toParams({ index: '1', timer_id: '  ' }), { index: '1' })
+    deepEqual(toParams({ index: ' ', timer_id: ' abc ' }), { timer_id: 'abc' })
+  })
+
+  test('message ID takes precedence over index', () => {
+    deepEqual(
+      toParams({ index: '2', message_id: '63f59467d68bfdeef6b3bfc3', focus: true }),
+      { message_id: '63f59467d68bfdeef6b3bfc3', focus: true },
+    )
+  })
+
+  test('numeric index from actions saved before v2.6.0 still works', () => {
+    deepEqual(toParams({ index: 1, timer_id: '' }), { index: 1 })
+    deepEqual(toParams({ index: 1, timer_id: 'abc' }), { timer_id: 'abc' })
+  })
+
+  test('leaves other empty text fields untouched', () => {
+    deepEqual(toParams({ index: '1', name: '', notes: '' }), { index: '1', name: '', notes: '' })
+  })
+})

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test'
 import { equal } from 'node:assert/strict'
 
-import { getTimerPhase } from '../src/state.js'
+import { getTimerPhase, initialState, updateMessageState } from '../src/state.js'
 import { deepEqual } from 'node:assert'
 import { createDropdownOptions } from '../src/utils/index.js'
 import { timerTriggers } from '../src/config.js'
@@ -27,6 +27,69 @@ describe('timer phases', () => {
     equal( getTimerPhase(0,       yellowSec, redSec), 'zero'     )
     equal( getTimerPhase(min(-1), yellowSec, redSec), 'negative' )
   })
+})
+
+describe('message state', () => {
+
+  /** Minimal stand-in for the module instance, capturing the variable values */
+  function createInstance () {
+    return {
+      state: structuredClone(initialState),
+      variables: /** @type {Record<string, any>} */ ({}),
+      setVariableValues (values) { Object.assign(this.variables, values) },
+      checkFeedbacks () {},
+    }
+  }
+
+  const message = {
+    _id: '63f59467d68bfdeef6b3bfc3',
+    showing: true,
+    text: 'Please wrap up',
+    color: 'red',
+    bold: true,
+    uppercase: false,
+  }
+
+  test('exposes the message while it is showing', () => {
+    const instance = createInstance()
+
+    updateMessageState.call(instance, message)
+
+    deepEqual(instance.variables, {
+      currentMessageId: '63f59467d68bfdeef6b3bfc3',
+      currentMessageText: 'Please wrap up',
+      currentMessageColor: 'red',
+    })
+  })
+
+  test('clears the variables once the message is hidden', () => {
+    const instance = createInstance()
+
+    updateMessageState.call(instance, message)
+    updateMessageState.call(instance, { ...message, showing: false })
+
+    deepEqual(instance.variables, {
+      currentMessageId: '',
+      currentMessageText: '',
+      currentMessageColor: '',
+    })
+
+    // The state itself keeps the message, feedbacks and actions still need it
+    equal(instance.state.message.text, 'Please wrap up')
+  })
+
+  test('seeds empty values when called without a message', () => {
+    const instance = createInstance()
+
+    updateMessageState.call(instance)
+
+    deepEqual(instance.variables, {
+      currentMessageId: '',
+      currentMessageText: '',
+      currentMessageColor: '',
+    })
+  })
+
 })
 
 describe('enums', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,9 +5,9 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
-"@companion-module/base@npm:^1.14.0":
-  version: 1.14.0
-  resolution: "@companion-module/base@npm:1.14.0"
+"@companion-module/base@npm:^1.14.1":
+  version: 1.14.1
+  resolution: "@companion-module/base@npm:1.14.1"
   dependencies:
     ajv: "npm:^8.17.1"
     colord: "npm:^2.9.3"
@@ -18,27 +18,27 @@ __metadata:
     p-queue: "npm:^6.6.2"
     p-timeout: "npm:^4.1.0"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/e9d79d01d024f4cbea2b58ba66d422ed8cd874a5f092a25c7c27220b52c34bfe3e5289758cf5dd40f5f36619bcf7e9f7ad978495d8010270dfd0e85bc9c8bf58
+  checksum: 10c0/55296836c01197e811ccf5dac9faa2b815668532754315c00b5fc14193fc969f58da0fc2e62eb572f0a3cfc1901ad56574000b389a386f8d929f4a9c6237140f
   languageName: node
   linkType: hard
 
-"@companion-module/tools@npm:^2.6.1":
-  version: 2.6.1
-  resolution: "@companion-module/tools@npm:2.6.1"
+"@companion-module/tools@npm:^2.7.2":
+  version: 2.7.2
+  resolution: "@companion-module/tools@npm:2.7.2"
   dependencies:
-    "@eslint/js": "npm:^9.39.2"
+    "@eslint/js": "npm:^9.39.3"
     eslint-config-prettier: "npm:^10.1.8"
-    eslint-plugin-n: "npm:^17.23.2"
+    eslint-plugin-n: "npm:^17.24.0"
     eslint-plugin-prettier: "npm:^5.5.5"
     find-up: "npm:^7.0.0"
     parse-author: "npm:^2.0.0"
-    semver: "npm:^7.7.3"
-    tar: "npm:^7.5.7"
-    webpack: "npm:^5.104.1"
+    semver: "npm:^7.7.4"
+    tar: "npm:^7.5.9"
+    webpack: "npm:^5.105.2"
     webpack-cli: "npm:^6.0.1"
     zx: "npm:^8.8.5"
   peerDependencies:
-    "@companion-module/base": ^1.12.0
+    "@companion-module/base": ^1.12.0 || ^2.0.0
     "@companion-surface/base": ^1.0.0
     eslint: ^9.36.0
     prettier: ^3.6.2
@@ -60,7 +60,7 @@ __metadata:
     companion-module-check: scripts/check-connection.js
     companion-surface-build: scripts/build-surface.js
     companion-surface-check: scripts/check-surface.js
-  checksum: 10c0/404718c14d6c9bb1747633efbbf0f07c24c9584d8db5feb7f9324575c144ca044c35d0a99fb6d21929902ce39019b872b8ec393423fb100ae2d1ad10b8c62934
+  checksum: 10c0/6942e52f1b89781bf48446834b36ce3d5256d885620926ec59363fa0bf238511330dde4a50f5176e8f70ff8fa5c9c44308585320a0a71e89417a93458d3edd48
   languageName: node
   linkType: hard
 
@@ -89,56 +89,56 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-array@npm:^0.23.3":
-  version: 0.23.3
-  resolution: "@eslint/config-array@npm:0.23.3"
+"@eslint/config-array@npm:^0.23.5":
+  version: 0.23.5
+  resolution: "@eslint/config-array@npm:0.23.5"
   dependencies:
-    "@eslint/object-schema": "npm:^3.0.3"
+    "@eslint/object-schema": "npm:^3.0.5"
     debug: "npm:^4.3.1"
     minimatch: "npm:^10.2.4"
-  checksum: 10c0/7c19027acf9110cc542513ff9f3ca73a61d127e900c24f0e8e4d5e18aa22baf08d1d5bc386563d2f9311095f3b7898fe9b627b590fe9232b745ef60d4443cf9f
+  checksum: 10c0/b24833c4c76e78ee075d306cd3f095db46b2db0f90cc13a6ee6e4275f9889731c05bf5403ab5fefb79c756e07ac9184ed0e04570341382f9eccbccc80e6d1a0c
   languageName: node
   linkType: hard
 
-"@eslint/config-helpers@npm:^0.5.2":
-  version: 0.5.3
-  resolution: "@eslint/config-helpers@npm:0.5.3"
+"@eslint/config-helpers@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "@eslint/config-helpers@npm:0.7.0"
   dependencies:
-    "@eslint/core": "npm:^1.1.1"
-  checksum: 10c0/c836476e839a79dcdc9f7e0013057cfe0341162180d50e5a08668edb4b4b6c520a3174011469f6ef02efd2affd092263c020e89d0a3452c801427b0ac003549a
+    "@eslint/core": "npm:^1.2.1"
+  checksum: 10c0/fd40d57d6f1db49f7b647048b88a433dc7f6522ef3edf855a43cb526ef4fc40622ceed0dc8de2e03d254f30f8e035370570de1d4bd8e7c2b1200131451e0d331
   languageName: node
   linkType: hard
 
-"@eslint/core@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@eslint/core@npm:1.1.1"
+"@eslint/core@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "@eslint/core@npm:1.2.1"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
-  checksum: 10c0/129c654c78afc1f6d61dccb0ce841be667f09f052f7d5642614b6ba5eeebd579ca6cc336d7b750d88625e61f7aad22fdd62bf83847fbfc10cc3e58cfe6c5072e
+  checksum: 10c0/10979b40588ecfef771fcb5013a542a35fb30692cc95a65f3481b0b36fbd89f5679efeb30d57f4eed35203d859aabace2a620177d6c536f71b299a1af2f3398f
   languageName: node
   linkType: hard
 
-"@eslint/js@npm:^9.39.2":
-  version: 9.39.2
-  resolution: "@eslint/js@npm:9.39.2"
-  checksum: 10c0/00f51c52b04ac79faebfaa65a9652b2093b9c924e945479f1f3945473f78aee83cbc76c8d70bbffbf06f7024626575b16d97b66eab16182e1d0d39daff2f26f5
+"@eslint/js@npm:^9.39.3":
+  version: 9.39.5
+  resolution: "@eslint/js@npm:9.39.5"
+  checksum: 10c0/49894e98ba313a7d3bfb1b20d55c0f9826be45a7db876fd84e533ac7f101b1d95b51cd22c6a6db3a45066b9c0d068c31b4a22fa0db8a6cc8744a25540efdb824
   languageName: node
   linkType: hard
 
-"@eslint/object-schema@npm:^3.0.3":
-  version: 3.0.3
-  resolution: "@eslint/object-schema@npm:3.0.3"
-  checksum: 10c0/4abbb7cba5419dce46ae8aa8e979fa190f2e906a8e1b5a8e22e4489f62a68dea3967679f66acbc0c3ef89f33252a7460e39fc2d6f2b4f616a137f3514eda4784
+"@eslint/object-schema@npm:^3.0.5":
+  version: 3.0.5
+  resolution: "@eslint/object-schema@npm:3.0.5"
+  checksum: 10c0/1db337431f520b99e9edda64ef5fafd7ec6a029843eeb608753025125b6649d861d843cffafafd3c4e37926d7d5f9ec0c6a8e3665c13c3da2144e8132892e92e
   languageName: node
   linkType: hard
 
-"@eslint/plugin-kit@npm:^0.6.1":
-  version: 0.6.1
-  resolution: "@eslint/plugin-kit@npm:0.6.1"
+"@eslint/plugin-kit@npm:^0.7.2":
+  version: 0.7.2
+  resolution: "@eslint/plugin-kit@npm:0.7.2"
   dependencies:
-    "@eslint/core": "npm:^1.1.1"
+    "@eslint/core": "npm:^1.2.1"
     levn: "npm:^0.4.1"
-  checksum: 10c0/f8354a7b92cc41e7a55d51986d192134be84f9dc0c91b5e649d075d733b56981c4ca8bf4460d54120c4c87b47984167bad2cb9bceb303f11b0a3bad22b3ed06a
+  checksum: 10c0/aafba08077bcd6d7dde6c2e21db18086046a88f914f29971a84cac9ad2d48952ded1b293e665e523805297eff756522dafa16f0062195e2c7143dcd1d47d11ed
   languageName: node
   linkType: hard
 
@@ -248,26 +248,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint-scope@npm:^3.7.7":
-  version: 3.7.7
-  resolution: "@types/eslint-scope@npm:3.7.7"
-  dependencies:
-    "@types/eslint": "npm:*"
-    "@types/estree": "npm:*"
-  checksum: 10c0/a0ecbdf2f03912679440550817ff77ef39a30fa8bfdacaf6372b88b1f931828aec392f52283240f0d648cf3055c5ddc564544a626bcf245f3d09fcb099ebe3cc
-  languageName: node
-  linkType: hard
-
-"@types/eslint@npm:*":
-  version: 9.6.1
-  resolution: "@types/eslint@npm:9.6.1"
-  dependencies:
-    "@types/estree": "npm:*"
-    "@types/json-schema": "npm:*"
-  checksum: 10c0/69ba24fee600d1e4c5abe0df086c1a4d798abf13792d8cfab912d76817fe1a894359a1518557d21237fbaf6eda93c5ab9309143dee4c59ef54336d1b3570420e
-  languageName: node
-  linkType: hard
-
 "@types/esrecurse@npm:^4.3.1":
   version: 4.3.1
   resolution: "@types/esrecurse@npm:4.3.1"
@@ -275,14 +255,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/estree@npm:*, @types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
+"@types/estree@npm:^1.0.6, @types/estree@npm:^1.0.8":
   version: 1.0.8
   resolution: "@types/estree@npm:1.0.8"
   checksum: 10c0/39d34d1afaa338ab9763f37ad6066e3f349444f9052b9676a7cc0252ef9485a41c6d81c9c4e0d26e9077993354edf25efc853f3224dd4b447175ef62bdcc86a5
   languageName: node
   linkType: hard
 
-"@types/json-schema@npm:*, @types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.9":
+"@types/json-schema@npm:^7.0.15, @types/json-schema@npm:^7.0.9":
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
@@ -496,15 +476,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn-import-phases@npm:^1.0.3":
-  version: 1.0.4
-  resolution: "acorn-import-phases@npm:1.0.4"
-  peerDependencies:
-    acorn: ^8.14.0
-  checksum: 10c0/338eb46fc1aed5544f628344cb9af189450b401d152ceadbf1f5746901a5d923016cd0e7740d5606062d374fdf6941c29bb515d2bd133c4f4242d5d4cd73a3c7
-  languageName: node
-  linkType: hard
-
 "acorn-jsx@npm:^5.3.2":
   version: 5.3.2
   resolution: "acorn-jsx@npm:5.3.2"
@@ -613,6 +584,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"brace-expansion@npm:^5.0.8":
+  version: 5.0.9
+  resolution: "brace-expansion@npm:5.0.9"
+  dependencies:
+    balanced-match: "npm:^4.0.2"
+  checksum: 10c0/3dea38884a1c3c8b1c9c44a7402a0c76fca460f70cffb3127242b0b4cbf4472019e022ade021eec44838ff19f1dac2625dfd11dd459d7e1e055b0698a8d52fec
+  languageName: node
+  linkType: hard
+
 "browserslist@npm:^4.28.1":
   version: 4.28.1
   resolution: "browserslist@npm:4.28.1"
@@ -718,7 +698,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:~4.3.1, debug@npm:~4.3.2":
+"debug@npm:~4.3.1":
   version: 4.3.5
   resolution: "debug@npm:4.3.5"
   dependencies:
@@ -771,13 +751,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"enhanced-resolve@npm:^5.17.1, enhanced-resolve@npm:^5.17.4":
+"enhanced-resolve@npm:^5.17.1":
   version: 5.18.4
   resolution: "enhanced-resolve@npm:5.18.4"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
   checksum: 10c0/8f6d42c8a0787a746c493e724c9de5d091cfe8e3f871f2464e2f78a6c55fa1a3aaba495334f923c8ea3ac23e1472491f79feef6fc0fb46a75169cb447ffbe2dc
+  languageName: node
+  linkType: hard
+
+"enhanced-resolve@npm:^5.24.4":
+  version: 5.24.5
+  resolution: "enhanced-resolve@npm:5.24.5"
+  dependencies:
+    graceful-fs: "npm:^4.2.4"
+    tapable: "npm:^2.3.3"
+  checksum: 10c0/76c32ce5485ecea0ef808c9289bc6f7c49ce85142943598d89a23a846f2909556d3dc6db97a007442a48c185baad5514c1c76d20a2656497f9511d13ccfab73b
   languageName: node
   linkType: hard
 
@@ -790,10 +780,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-module-lexer@npm:^2.0.0":
-  version: 2.0.0
-  resolution: "es-module-lexer@npm:2.0.0"
-  checksum: 10c0/ae78dbbd43035a4b972c46cfb6877e374ea290adfc62bc2f5a083fea242c0b2baaab25c5886af86be55f092f4a326741cb94334cd3c478c383fdc8a9ec5ff817
+"es-module-lexer@npm:^2.1.0":
+  version: 2.3.1
+  resolution: "es-module-lexer@npm:2.3.1"
+  checksum: 10c0/ada8b222772b5b8ea92eb6054c383233207418621855a07b480fdd36979b658a41414be09e793fcdd8a67a182741475f47830a01ff2ebd4353d7f6965c7c45f9
   languageName: node
   linkType: hard
 
@@ -846,9 +836,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-n@npm:^17.23.2":
-  version: 17.23.2
-  resolution: "eslint-plugin-n@npm:17.23.2"
+"eslint-plugin-n@npm:^17.24.0":
+  version: 17.24.0
+  resolution: "eslint-plugin-n@npm:17.24.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.5.0"
     enhanced-resolve: "npm:^5.17.1"
@@ -861,7 +851,7 @@ __metadata:
     ts-declaration-location: "npm:^1.0.6"
   peerDependencies:
     eslint: ">=8.23.0"
-  checksum: 10c0/3808dad65628bc2dd74ebb9e7a255398f87ca348b4970307898b422bfe2302764d518f6a70d891b1fc45b08ea99ccf5ea4b3cd2d1f21f872bb60a4cdbfb22b68
+  checksum: 10c0/65b6c9ccd4d69296df9bdc0517bdbbc71e5f1ec065e80623c49148ff7813829bd3568154a016fefc06749476f3fdadc0e1afa61a15695893a3ca3da161c9fe86
   languageName: node
   linkType: hard
 
@@ -921,16 +911,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^10.0.3":
-  version: 10.0.3
-  resolution: "eslint@npm:10.0.3"
+"eslint@npm:^10.8.0":
+  version: 10.8.0
+  resolution: "eslint@npm:10.8.0"
   dependencies:
     "@eslint-community/eslint-utils": "npm:^4.8.0"
     "@eslint-community/regexpp": "npm:^4.12.2"
-    "@eslint/config-array": "npm:^0.23.3"
-    "@eslint/config-helpers": "npm:^0.5.2"
-    "@eslint/core": "npm:^1.1.1"
-    "@eslint/plugin-kit": "npm:^0.6.1"
+    "@eslint/config-array": "npm:^0.23.5"
+    "@eslint/config-helpers": "npm:^0.7.0"
+    "@eslint/core": "npm:^1.2.1"
+    "@eslint/plugin-kit": "npm:^0.7.2"
     "@humanfs/node": "npm:^0.16.6"
     "@humanwhocodes/module-importer": "npm:^1.0.1"
     "@humanwhocodes/retry": "npm:^0.4.2"
@@ -941,7 +931,7 @@ __metadata:
     escape-string-regexp: "npm:^4.0.0"
     eslint-scope: "npm:^9.1.2"
     eslint-visitor-keys: "npm:^5.0.1"
-    espree: "npm:^11.1.1"
+    espree: "npm:^11.2.0"
     esquery: "npm:^1.7.0"
     esutils: "npm:^2.0.2"
     fast-deep-equal: "npm:^3.1.3"
@@ -952,7 +942,7 @@ __metadata:
     imurmurhash: "npm:^0.1.4"
     is-glob: "npm:^4.0.0"
     json-stable-stringify-without-jsonify: "npm:^1.0.1"
-    minimatch: "npm:^10.2.4"
+    minimatch: "npm:^10.2.5"
     natural-compare: "npm:^1.4.0"
     optionator: "npm:^0.9.3"
   peerDependencies:
@@ -962,11 +952,11 @@ __metadata:
       optional: true
   bin:
     eslint: bin/eslint.js
-  checksum: 10c0/fbbb4d99cb6af5c30b163b7898241dbac1cd1cee0e6746d5732a95e3b1e68b5bea0bc27cb78e8440a39cf4cc98c7f52cf5ed8d7c2bbdf2232662476d113c41fc
+  checksum: 10c0/2dbc523578834088615f388e08418d2620b25655f7a398f6d415765fa2a3a25d6b8b43bd3293d40f977e12752323a841d52654a2648697a00c0102c9794bb3dc
   languageName: node
   linkType: hard
 
-"espree@npm:^11.1.1":
+"espree@npm:^11.2.0":
   version: 11.2.0
   resolution: "espree@npm:11.2.0"
   dependencies:
@@ -1170,13 +1160,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob-to-regexp@npm:^0.4.1":
-  version: 0.4.1
-  resolution: "glob-to-regexp@npm:0.4.1"
-  checksum: 10c0/0486925072d7a916f052842772b61c3e86247f0a80cc0deb9b5a3e8a1a9faad5b04fb6f58986a09f34d3e96cd2a22a24b7e9882fb1cf904c31e9a310de96c429
-  languageName: node
-  linkType: hard
-
 "globals@npm:^15.11.0":
   version: 15.15.0
   resolution: "globals@npm:15.15.0"
@@ -1313,13 +1296,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"json-parse-even-better-errors@npm:^2.3.1":
-  version: 2.3.1
-  resolution: "json-parse-even-better-errors@npm:2.3.1"
-  checksum: 10c0/140932564c8f0b88455432e0f33c4cb4086b8868e37524e07e723f4eaedb9425bdc2bafd71bd1d9765bd15fd1e2d126972bc83990f55c467168c228c24d665f3
-  languageName: node
-  linkType: hard
-
 "json-schema-traverse@npm:^0.4.1":
   version: 0.4.1
   resolution: "json-schema-traverse@npm:0.4.1"
@@ -1367,13 +1343,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loader-runner@npm:^4.3.1":
-  version: 4.3.1
-  resolution: "loader-runner@npm:4.3.1"
-  checksum: 10c0/a523b6329f114e0a98317158e30a7dfce044b731521be5399464010472a93a15ece44757d1eaed1d8845019869c5390218bc1c7c3110f4eeaef5157394486eac
-  languageName: node
-  linkType: hard
-
 "locate-path@npm:^5.0.0":
   version: 5.0.0
   resolution: "locate-path@npm:5.0.0"
@@ -1408,19 +1377,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:1.52.0":
-  version: 1.52.0
-  resolution: "mime-db@npm:1.52.0"
-  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.1.27":
-  version: 2.1.35
-  resolution: "mime-types@npm:2.1.35"
-  dependencies:
-    mime-db: "npm:1.52.0"
-  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
   languageName: node
   linkType: hard
 
@@ -1437,6 +1397,54 @@ __metadata:
   dependencies:
     brace-expansion: "npm:^5.0.2"
   checksum: 10c0/35f3dfb7b99b51efd46afd378486889f590e7efb10e0f6a10ba6800428cf65c9a8dedb74427d0570b318d749b543dc4e85f06d46d2858bc8cac7e1eb49a95945
+  languageName: node
+  linkType: hard
+
+"minimatch@npm:^10.2.5":
+  version: 10.2.6
+  resolution: "minimatch@npm:10.2.6"
+  dependencies:
+    brace-expansion: "npm:^5.0.8"
+  checksum: 10c0/4559a836243b98bd4d17ea9f7edae698717c76399eea7be374f3737f33164e4907f19e9726891ddeb122f750a5a7fa80d2ac43e851d6e5984dc4ff42ec127d3a
+  languageName: node
+  linkType: hard
+
+"minimizer-webpack-plugin@npm:^5.6.1":
+  version: 5.6.1
+  resolution: "minimizer-webpack-plugin@npm:5.6.1"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.25"
+    jest-worker: "npm:^27.4.5"
+    schema-utils: "npm:^4.3.0"
+    terser: "npm:^5.31.1"
+  peerDependencies:
+    webpack: ^5.1.0
+  peerDependenciesMeta:
+    "@minify-html/node":
+      optional: true
+    "@swc/core":
+      optional: true
+    "@swc/css":
+      optional: true
+    "@swc/html":
+      optional: true
+    clean-css:
+      optional: true
+    cssnano:
+      optional: true
+    csso:
+      optional: true
+    esbuild:
+      optional: true
+    html-minifier-terser:
+      optional: true
+    lightningcss:
+      optional: true
+    postcss:
+      optional: true
+    uglify-js:
+      optional: true
+  checksum: 10c0/4bf4e8bc2827e3724a53e04465493ee4b52f2a4a18e89e23c72905462557107bc9f5396035841fb5e4f86630c8a783eb4f13c26a3b1544f621b75ea8bedca3f2
   languageName: node
   linkType: hard
 
@@ -1691,15 +1699,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"randombytes@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "randombytes@npm:2.1.0"
-  dependencies:
-    safe-buffer: "npm:^5.1.0"
-  checksum: 10c0/50395efda7a8c94f5dffab564f9ff89736064d32addf0cc7e8bf5e4166f09f8ded7a0849ca6c2d2a59478f7d90f78f20d8048bca3cdf8be09d8e8a10790388f3
-  languageName: node
-  linkType: hard
-
 "rechoir@npm:^0.8.0":
   version: 0.8.0
   resolution: "rechoir@npm:0.8.0"
@@ -1765,13 +1764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:^5.1.0":
-  version: 5.2.1
-  resolution: "safe-buffer@npm:5.2.1"
-  checksum: 10c0/6501914237c0a86e9675d4e51d89ca3c21ffd6a31642efeba25ad65720bce6921c9e7e974e5be91a786b25aa058b5303285d3c15dbabf983a919f5f630d349f3
-  languageName: node
-  linkType: hard
-
 "schema-utils@npm:^4.3.0, schema-utils@npm:^4.3.3":
   version: 4.3.3
   resolution: "schema-utils@npm:4.3.3"
@@ -1784,7 +1776,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.3":
+"semver@npm:^7.5.4, semver@npm:^7.6.3":
   version: 7.7.3
   resolution: "semver@npm:7.7.3"
   bin:
@@ -1793,12 +1785,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"serialize-javascript@npm:^6.0.2":
-  version: 6.0.2
-  resolution: "serialize-javascript@npm:6.0.2"
-  dependencies:
-    randombytes: "npm:^2.1.0"
-  checksum: 10c0/2dd09ef4b65a1289ba24a788b1423a035581bef60817bea1f01eda8e3bda623f86357665fe7ac1b50f6d4f583f97db9615b3f07b2a2e8cbcb75033965f771dd2
+"semver@npm:^7.7.4":
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -1827,15 +1819,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"socket.io-client@npm:^4.8.1":
-  version: 4.8.1
-  resolution: "socket.io-client@npm:4.8.1"
+"socket.io-client@npm:^4.8.3":
+  version: 4.8.3
+  resolution: "socket.io-client@npm:4.8.3"
   dependencies:
     "@socket.io/component-emitter": "npm:~3.1.0"
-    debug: "npm:~4.3.2"
+    debug: "npm:~4.4.1"
     engine.io-client: "npm:~6.6.1"
     socket.io-parser: "npm:~4.2.4"
-  checksum: 10c0/544c49cc8cc77118ef68b758a8a580c8e680a5909cae05c566d2cc07ec6cd6720a4f5b7e985489bf2a8391749177a5437ac30b8afbdf30b9da6402687ad51c86
+  checksum: 10c0/76c0d86de0b636d0bf5011cf3425212c900f43dac632db6eb493816920cd035af7ddd92fea9a106b45eb347405953c0414eb3a5d465b180215e46fc8b61420b3
   languageName: node
   linkType: hard
 
@@ -1870,10 +1862,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "stagetimerio-api@workspace:."
   dependencies:
-    "@companion-module/base": "npm:^1.14.0"
-    "@companion-module/tools": "npm:^2.6.1"
-    eslint: "npm:^10.0.3"
-    socket.io-client: "npm:^4.8.1"
+    "@companion-module/base": "npm:^1.14.1"
+    "@companion-module/tools": "npm:^2.7.2"
+    eslint: "npm:^10.8.0"
+    socket.io-client: "npm:^4.8.3"
   languageName: unknown
   linkType: soft
 
@@ -1909,38 +1901,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.7":
-  version: 7.5.21
-  resolution: "tar@npm:7.5.21"
+"tapable@npm:^2.3.3":
+  version: 2.3.3
+  resolution: "tapable@npm:2.3.3"
+  checksum: 10c0/47992e861053f861154e92fb4a98ac4ab47b6463717e60792dd1e8c755da0c4964cd8bb68c308a9066d6da89000b6310457b4d5d985c30de4ccc29066068cc17
+  languageName: node
+  linkType: hard
+
+"tar@npm:^7.5.9":
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/bce0e51692356078e6f6a909d5c93f5b4c099c097ffea19b1b1bf10385539a429baba26bca59aabbace68c4519d16f2f1c07afe7eaab55876a449a032480fabc
-  languageName: node
-  linkType: hard
-
-"terser-webpack-plugin@npm:^5.3.16":
-  version: 5.3.16
-  resolution: "terser-webpack-plugin@npm:5.3.16"
-  dependencies:
-    "@jridgewell/trace-mapping": "npm:^0.3.25"
-    jest-worker: "npm:^27.4.5"
-    schema-utils: "npm:^4.3.0"
-    serialize-javascript: "npm:^6.0.2"
-    terser: "npm:^5.31.1"
-  peerDependencies:
-    webpack: ^5.1.0
-  peerDependenciesMeta:
-    "@swc/core":
-      optional: true
-    esbuild:
-      optional: true
-    uglify-js:
-      optional: true
-  checksum: 10c0/39e37c5b3015c1a5354a3633f77235677bfa06eac2608ce26d258b1d1a74070a99910319a6f2f2c437eb61dc321f66434febe01d78e73fa96b4d4393b813f4cf
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 
@@ -2022,13 +1999,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"watchpack@npm:^2.4.4":
-  version: 2.4.4
-  resolution: "watchpack@npm:2.4.4"
+"watchpack@npm:^2.5.2":
+  version: 2.5.2
+  resolution: "watchpack@npm:2.5.2"
   dependencies:
-    glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.1.2"
-  checksum: 10c0/6c0901f75ce245d33991225af915eea1c5ae4ba087f3aee2b70dd377d4cacb34bef02a48daf109da9d59b2d31ec6463d924a0d72f8618ae1643dd07b95de5275
+  checksum: 10c0/8290e89f03e1e7136e1ef9b8d04bd03822963fa4b442781a40999e7b9ba29ab333a7a5285312b2d4f3e91bc8c5c526cf1f91f5ce0e857dafe56db28ab1c17dca
   languageName: node
   linkType: hard
 
@@ -2073,48 +2049,43 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-sources@npm:^3.3.3":
-  version: 3.3.3
-  resolution: "webpack-sources@npm:3.3.3"
-  checksum: 10c0/ab732f6933b513ba4d505130418995ddef6df988421fccf3289e53583c6a39e205c4a0739cee98950964552d3006604912679c736031337fb4a9d78d8576ed40
+"webpack-sources@npm:^3.5.1":
+  version: 3.5.1
+  resolution: "webpack-sources@npm:3.5.1"
+  checksum: 10c0/9463e6895ea0e40b243936ab338d410bec04aff3a43f0cde8cc916a16effece071990ded93c8cad2a73bd7c9b8c293fc27130e440d55df613ea20284de657dd8
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.104.1":
-  version: 5.104.1
-  resolution: "webpack@npm:5.104.1"
+"webpack@npm:^5.105.2":
+  version: 5.109.2
+  resolution: "webpack@npm:5.109.2"
   dependencies:
-    "@types/eslint-scope": "npm:^3.7.7"
     "@types/estree": "npm:^1.0.8"
     "@types/json-schema": "npm:^7.0.15"
     "@webassemblyjs/ast": "npm:^1.14.1"
     "@webassemblyjs/wasm-edit": "npm:^1.14.1"
     "@webassemblyjs/wasm-parser": "npm:^1.14.1"
-    acorn: "npm:^8.15.0"
-    acorn-import-phases: "npm:^1.0.3"
+    acorn: "npm:^8.16.0"
     browserslist: "npm:^4.28.1"
     chrome-trace-event: "npm:^1.0.2"
-    enhanced-resolve: "npm:^5.17.4"
-    es-module-lexer: "npm:^2.0.0"
+    enhanced-resolve: "npm:^5.24.4"
+    es-module-lexer: "npm:^2.1.0"
     eslint-scope: "npm:5.1.1"
     events: "npm:^3.2.0"
-    glob-to-regexp: "npm:^0.4.1"
     graceful-fs: "npm:^4.2.11"
-    json-parse-even-better-errors: "npm:^2.3.1"
-    loader-runner: "npm:^4.3.1"
-    mime-types: "npm:^2.1.27"
+    mime-db: "npm:^1.54.0"
+    minimizer-webpack-plugin: "npm:^5.6.1"
     neo-async: "npm:^2.6.2"
     schema-utils: "npm:^4.3.3"
     tapable: "npm:^2.3.0"
-    terser-webpack-plugin: "npm:^5.3.16"
-    watchpack: "npm:^2.4.4"
-    webpack-sources: "npm:^3.3.3"
+    watchpack: "npm:^2.5.2"
+    webpack-sources: "npm:^3.5.1"
   peerDependenciesMeta:
     webpack-cli:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 10c0/ea78c57f80bbd7684f4f1bb38a18408ab0ef4c5b962e25ad382c595d10b9e9701e077f5248a8cef5f127a55902698664c18837e64243bb972fbecf4e5d9aaab0
+  checksum: 10c0/524b8afe327a2452ed1d12340cf40fc9d6c65cb72108efeb704cce55ed93b8532be23e5179bbc3f537003b8de204fab0753a0050239bfcb4871cc8a2b3c1a723
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
New features:
- Adds variables for the message currently showing on the viewer:
  - `$(stagetimer:currentMessageId)` - Message ID
  - `$(stagetimer:currentMessageText)` - Message text
  - `$(stagetimer:currentMessageColor)` - Message color
  - The variables are empty while no message is showing.

Fixes:
- Fixes targeting a timer by ID in the `Timer: Start`, `Timer: Stop`, `Timer: Toggle playback`, `Timer: Reset`, and `Timer: Update timer` actions. The `Timer ID` field now supports variables (e.g. `$(stagetimer:currentTimerId)`), and the `Timer index` field can be left blank. Previously the index was always sent alongside the ID, which the API rejects, so the action did nothing.
- Adds variable support to the `Message ID` field of the message actions.

Changes:
- The `Timer index` and `Message index` fields are now text inputs (instead of number inputs) so they can be cleared and accept variables. Existing buttons keep working unchanged.
- When both an index and an ID are set, the ID now takes precedence instead of the request failing.