### PR TITLE
Release v2.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 
+## v2.6.1
+
+Fixes:
+- Fixes the current and next timer variables keeping stale values when there is no such timer. The next timer variables now go empty once the last timer is selected, and the current timer variables go empty when no timer is selected. This makes `$(stagetimer:nextTimerId)` usable to detect the end of the rundown, for example to loop back to the first timer or stop playback. ([#20](https://github.com/bitfocus/companion-module-stagetimerio-api/issues/20))
+- Fixes `$(stagetimer:currentTimerDurationAsMs)`, `$(stagetimer:nextTimerDurationAsMs)`, `$(stagetimer:currentTimerAppearance)`, and `$(stagetimer:nextTimerAppearance)` showing `$NA` instead of an empty value when no timer is set.
+
 ## v2.6.0
 
 New features:

--- a/companion/HELP.md
+++ b/companion/HELP.md
@@ -158,7 +158,9 @@ The time display is equal to the Stagetimer output, taking [timer appearance](ht
 - `$(stagetimer:currentTimerRemainingMinutes)` - Timer remaining time (minutes)
 - `$(stagetimer:currentTimerRemainingSeconds)` - Timer remaining time (seconds)
 
-**Current Timer**
+**Current Timer**  
+The timer currently selected in the room. These variables are empty while no timer is selected.
+
 - `$(stagetimer:currentTimerId)` - Timer ID
 - `$(stagetimer:currentTimerName)` - Timer name
 - `$(stagetimer:currentTimerSpeaker)` - Timer speaker
@@ -173,7 +175,9 @@ The time display is equal to the Stagetimer output, taking [timer appearance](ht
 - `$(stagetimer:currentTimerLabel2)` - Timer label 2
 - `$(stagetimer:currentTimerLabel3)` - Timer label 3
 
-**Next Timer**
+**Next Timer**  
+The timer that follows the current one. These variables are empty when the last timer is selected, so `$(stagetimer:nextTimerId)` can be used to detect the end of the rundown.
+
 - `$(stagetimer:nextTimerId)` - Timer ID
 - `$(stagetimer:nextTimerName)` - Timer name
 - `$(stagetimer:nextTimerSpeaker)` - Timer speaker

--- a/companion/manifest.json
+++ b/companion/manifest.json
@@ -3,7 +3,7 @@
   "name": "stagetimer",
   "shortname": "stagetimer",
   "description": "Stagetimer.io module for Companion v3",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "license": "MIT",
   "repository": "git+https://github.com/bitfocus/companion-module-stagetimerio-api.git",
   "bugs": "https://github.com/bitfocus/companion-module-stagetimerio-api/issues",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stagetimerio-api",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "description": "Stagetimer.io module for Companion v3",
   "main": "src/index.js",
   "type": "module",

--- a/src/socket.js
+++ b/src/socket.js
@@ -8,6 +8,7 @@ import {
   updateNextTimerState,
   updateFlashingState,
   updateMessageState,
+  createEmptyTimerState,
 } from './state.js'
 import { actionIdType } from './actions.js'
 
@@ -228,7 +229,8 @@ export function socketStart (instance) {
   socket.on(stagetimerEvents.current_timer, (payload) => {
     instance.log('debug', `Event: 'current_timer' ${JSON.stringify(payload)}`)
 
-    if (!payload) return updateCurrentTimerState.call(instance, {})
+    // A null payload means no timer is selected, clear the state
+    if (!payload) return updateCurrentTimerState.call(instance, createEmptyTimerState())
 
     const {
       _id,
@@ -262,7 +264,8 @@ export function socketStart (instance) {
   socket.on(stagetimerEvents.next_timer, (payload) => {
     instance.log('debug', `Event: 'next_timer' ${JSON.stringify(payload)}`)
 
-    if (!payload) return updateNextTimerState.call(instance, {})
+    // A null payload means this is the last timer, clear the state
+    if (!payload) return updateNextTimerState.call(instance, createEmptyTimerState())
 
     const {
       _id,

--- a/src/state.js
+++ b/src/state.js
@@ -65,6 +65,30 @@ export function getTimerPhase (timeRemaining, yellowTime = 0, redTime = 0) {
   return timerPhases.default
 }
 
+/**
+ * A blank timer, used as the initial state and to clear `current_timer` /
+ * `next_timer` when the API reports there is none (null socket payload).
+ *
+ * Returns a fresh object every call so the two slices don't share a `labels` array.
+ *
+ * @returns {TimerState}
+ */
+export function createEmptyTimerState () {
+  return {
+    _id: '',
+    name: '',
+    speaker: '',
+    notes: '',
+    duration: '',
+    appearance: '',
+    wrap_up_yellow: 0,
+    wrap_up_red: 0,
+    start_time: '',
+    start_time_uses_date: false,
+    labels: [],
+  }
+}
+
 /** @type {State} */
 export const initialState = {
   connection: {
@@ -89,30 +113,8 @@ export const initialState = {
     lastStop: 0,
     phase: undefined,
   },
-  current_timer: {
-    name: '',
-    speaker: '',
-    notes: '',
-    duration: '',
-    appearance: '',
-    wrap_up_yellow: 0,
-    wrap_up_red: 0,
-    start_time: '',
-    start_time_uses_date: '',
-    labels: [],
-  },
-  next_timer: {
-    name: '',
-    speaker: '',
-    notes: '',
-    duration: '',
-    appearance: '',
-    wrap_up_yellow: 0,
-    wrap_up_red: 0,
-    start_time: '',
-    start_time_uses_date: '',
-    labels: [],
-  },
+  current_timer: createEmptyTimerState(),
+  next_timer: createEmptyTimerState(),
   message: {
     _id: '',
     showing: false,
@@ -261,8 +263,8 @@ export function updateCurrentTimerState (newState) {
     [variableType.currentTimerNotes]: updatedState.notes,
     [variableType.currentTimerSpeaker]: updatedState.speaker,
     [variableType.currentTimerDuration]: updatedState.duration,
-    [variableType.currentTimerDurationAsMs]: durationToMs(updatedState.duration),
-    [variableType.currentTimerAppearance]: timerAppearancesLabels[updatedState.appearance],
+    [variableType.currentTimerDurationAsMs]: durationToMs(updatedState.duration) ?? '',
+    [variableType.currentTimerAppearance]: timerAppearancesLabels[updatedState.appearance] ?? '',
     [variableType.currentTimerStartTime12h]: start ? formatTimeOfDay(start, { timezone, format: '12h' }) : '',
     [variableType.currentTimerStartTime24h]: start ? formatTimeOfDay(start, { timezone, format: '24h' }) : '',
     [variableType.currentTimerLabels]: labels.map(l => l.name).join(', '),
@@ -309,8 +311,8 @@ export function updateNextTimerState (newState) {
     [variableType.nextTimerNotes]: updatedState.notes,
     [variableType.nextTimerSpeaker]: updatedState.speaker,
     [variableType.nextTimerDuration]: updatedState.duration,
-    [variableType.nextTimerDurationAsMs]: durationToMs(updatedState.duration),
-    [variableType.nextTimerAppearance]: timerAppearancesLabels[updatedState.appearance],
+    [variableType.nextTimerDurationAsMs]: durationToMs(updatedState.duration) ?? '',
+    [variableType.nextTimerAppearance]: timerAppearancesLabels[updatedState.appearance] ?? '',
     [variableType.nextTimerStartTime12h]: start ? formatTimeOfDay(start, { timezone, format: '12h' }) : '',
     [variableType.nextTimerStartTime24h]: start ? formatTimeOfDay(start, { timezone, format: '24h' }) : '',
     [variableType.nextTimerLabels]: labels.map(l => l.name).join(', '),

--- a/src/types.js
+++ b/src/types.js
@@ -157,6 +157,7 @@
 
 /**
  * @typedef {object} TimerState
+ * @property {string} [_id]
  * @property {string} name
  * @property {string} notes
  * @property {string} speaker

--- a/tests/state.test.js
+++ b/tests/state.test.js
@@ -1,7 +1,7 @@
 import { describe, test } from 'node:test'
 import { equal } from 'node:assert/strict'
 
-import { getTimerPhase, initialState, updateMessageState } from '../src/state.js'
+import { createEmptyTimerState, getTimerPhase, initialState, updateMessageState, updateNextTimerState } from '../src/state.js'
 import { deepEqual } from 'node:assert'
 import { createDropdownOptions } from '../src/utils/index.js'
 import { timerTriggers } from '../src/config.js'
@@ -88,6 +88,77 @@ describe('message state', () => {
       currentMessageText: '',
       currentMessageColor: '',
     })
+  })
+
+})
+
+describe('next timer state', () => {
+
+  /** Minimal stand-in for the module instance, capturing the variable values */
+  function createInstance () {
+    return {
+      state: structuredClone(initialState),
+      variables: /** @type {Record<string, any>} */ ({}),
+      setVariableValues (values) { Object.assign(this.variables, values) },
+      checkFeedbacks () {},
+    }
+  }
+
+  const timer = {
+    _id: '63a422789477ef3e82c3597b',
+    name: 'Introduction',
+    speaker: 'Tom',
+    notes: 'Keep it short',
+    duration: '0:05:00',
+    appearance: 'COUNTDOWN',
+    wrap_up_yellow: 60,
+    wrap_up_red: 15,
+    start_time: '',
+    start_time_uses_date: false,
+    labels: [{ name: 'VT', color: '#F44336' }],
+  }
+
+  test('exposes the next timer', () => {
+    const instance = createInstance()
+
+    updateNextTimerState.call(instance, timer)
+
+    equal(instance.variables.nextTimerId, '63a422789477ef3e82c3597b')
+    equal(instance.variables.nextTimerName, 'Introduction')
+    equal(instance.variables.nextTimerDurationAsMs, min(5))
+  })
+
+  // The socket sends a null payload once the last timer is selected
+  test('clears the variables when there is no next timer', () => {
+    const instance = createInstance()
+
+    updateNextTimerState.call(instance, timer)
+    updateNextTimerState.call(instance, createEmptyTimerState())
+
+    deepEqual(instance.variables, {
+      nextTimerId: '',
+      nextTimerName: '',
+      nextTimerNotes: '',
+      nextTimerSpeaker: '',
+      nextTimerDuration: '',
+      nextTimerDurationAsMs: '',
+      nextTimerAppearance: '',
+      nextTimerStartTime12h: '',
+      nextTimerStartTime24h: '',
+      nextTimerLabels: '',
+      nextTimerLabel1: '',
+      nextTimerLabel2: '',
+      nextTimerLabel3: '',
+    })
+  })
+
+  test('empty timer states do not share a labels array', () => {
+    const a = createEmptyTimerState()
+    const b = createEmptyTimerState()
+
+    a.labels.push({ name: 'VT', color: '#F44336' })
+
+    equal(b.labels.length, 0)
   })
 
 })


### PR DESCRIPTION
Fixes:
- Fixes the current and next timer variables keeping stale values when there is no such timer. The next timer variables now go empty once the last timer is selected, and the current timer variables go empty when no timer is selected. This makes `$(stagetimer:nextTimerId)` usable to detect the end of the rundown, for example to loop back to the first timer or stop playback. ([#20](https://github.com/bitfocus/companion-module-stagetimerio-api/issues/20))
- Fixes `$(stagetimer:currentTimerDurationAsMs)`, `$(stagetimer:nextTimerDurationAsMs)`, `$(stagetimer:currentTimerAppearance)`, and `$(stagetimer:nextTimerAppearance)` showing `$NA` instead of an empty value when no timer is set.